### PR TITLE
`chown` restricted to existing files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = crlf
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_size = 2
+
+[*.conf]
+indent_size = 8

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -36,7 +36,7 @@ for i in logs/ \
               media/video/ \
               media/temp/ \
               recovery/install/data; do
-      chown www-data /var/www/html/$i
+      [ -e /var/www/html/$i ] && chown www-data /var/www/html/$i
 done
 echo "done"
 


### PR DESCRIPTION
I noticed some messages on startup:

```
chown: cannot access '/var/www/html/logs/': No such file or directory
chown: cannot access '/var/www/html/recovery/': No such file or directory
chown: cannot access '/var/www/html/recovery/install/data': No such file or directory
```

I fixed this for me by adding a small test in front of `chown` to check if the file exists.

And I added an [.editorconfig](http://editorconfig.org/), so the next contributor will not mess up the code style.